### PR TITLE
feat // remove method open from port interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/grid-x/serial
+
+go 1.13

--- a/serial.go
+++ b/serial.go
@@ -50,15 +50,9 @@ type RS485Config struct {
 }
 
 // Port is the interface for controlling serial port.
-type Port interface {
-	io.ReadWriteCloser
-	// Connect connects to the serial port.
-	Open(*Config) error
-}
+type Port io.ReadWriteCloser
 
 // Open opens a serial port.
-func Open(c *Config) (p Port, err error) {
-	p = New()
-	err = p.Open(c)
-	return
+func Open(c *Config) (Port, error) {
+	return open(c)
 }


### PR DESCRIPTION
Since the open method depends on "serial.Config", the port interface always
contains a dependency to the serial package. To prevent this, the method
is removed. This change has no side effects.
The usage has not changed and can be tested with the example and the existing
unit test.
For this purpose virtual interfaces can be created with socat.
"socat -d -d pty,link=/dev/ttys009,raw,echo=0 pty,link=/dev/ttys010,raw,echo=0"
