### PR TITLE
feat(serial): protect port from concurrent access

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -6,6 +6,7 @@ package serial
 import (
 	"errors"
 	"io"
+	"sync"
 	"time"
 )
 
@@ -50,7 +51,10 @@ type RS485Config struct {
 }
 
 // Port is the interface for controlling serial port.
-type Port io.ReadWriteCloser
+type Port interface {
+	io.ReadWriteCloser
+	sync.Locker
+}
 
 // Open opens a serial port.
 func Open(c *Config) (Port, error) {

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -14,6 +15,8 @@ import (
 
 // port implements Port interface.
 type port struct {
+	sync.Mutex
+
 	fd         int
 	oldTermios *syscall.Termios
 

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -2,10 +2,13 @@ package serial
 
 import (
 	"fmt"
+	"sync"
 	"syscall"
 )
 
 type port struct {
+	sync.Mutex
+
 	handle syscall.Handle
 
 	oldDCB      c_DCB


### PR DESCRIPTION
during the serial communication we do not want to cause errors by concurrent
accesses. Therefore we can protect the port with a mutex. To do this from
outside the package, the port interface has been extended.