### PR TITLE
Fix hang in Read() if serial port become inaccessible while reading

### DIFF
--- a/serial_posix.go
+++ b/serial_posix.go
@@ -112,7 +112,7 @@ func (p *port) Read(b []byte) (n int, err error) {
 		return
 	}
 	n, err = syscall.Read(fd, b)
-	if n == 0 {
+	if n == 0 && err == nil {
 		err = io.ErrUnexpectedEOF
 	}
 	return

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -112,6 +112,9 @@ func (p *port) Read(b []byte) (n int, err error) {
 		return
 	}
 	n, err = syscall.Read(fd, b)
+	if n == 0 {
+		err = io.ErrUnexpectedEOF
+	}
 	return
 }
 


### PR DESCRIPTION
This may be reproduced with `while sleep 0.1; do socat -x pty,link=/tmp/ttyV0,waitslave,group-late=dialout,mode=660 TCP:invalid.host:1234; done`, after trying to read some registers from /tmp/ttyV0 thread goes hang.

The idea of this solution is based on stackoverflow discussion: https://stackoverflow.com/questions/34170350/detecting-if-a-character-device-has-disconnected-in-linux-in-with-termios-api-c

Note that https://man7.org/linux/man-pages/man2/select.2.html says:

> On Linux, select() may report a socket file descriptor as "ready
for reading", while nevertheless a subsequent read blocks.  This
could for example happen when data has arrived but upon
examination has the wrong checksum and is discarded.  There may
be other circumstances in which a file descriptor is spuriously
reported as ready

Wrong checksum case isn't acceptable for serial port, but there may be other unknown side effects by this pull request. Unfortunately I don't found better way to determine that serial port is dead. 