### PR TITLE
Update capitalization typo in Open function preventing build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/grid-x/serial
 
 go 1.13
+
+replace github.com/grid-x/serial v0.0.0 => github.com/jbarfield/serial v0.0.0-20210928151416-13225370e2d3

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/grid-x/serial
 
 go 1.13
 
-replace github.com/grid-x/serial v0.0.0 => github.com/jbarfield/serial v0.0.0-20210928151416-13225370e2d3
+replace github.com/grid-x/serial v0.0.0-20191104121038-e24bc9bf6f08 => github.com/jbarfield/serial v0.0.0-20210928151416-13225370e2d3

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/grid-x/serial
 
 go 1.13
 
-replace github.com/grid-x/serial v0.0.0-20191104121038-e24bc9bf6f08 => github.com/jbarfield/serial v0.0.0-20210928151416-13225370e2d3
+replace github.com/grid-x/serial v0.0.0-20191104121038-e24bc9bf6f08 => github.com/jbarfield/serial v0.0.0

--- a/serial.go
+++ b/serial.go
@@ -54,5 +54,5 @@ type Port io.ReadWriteCloser
 
 // Open opens a serial port.
 func Open(c *Config) (Port, error) {
-	return open(c)
+	return Open(c)
 }


### PR DESCRIPTION
On SmartOS/ (illumos): `go build` fails with an `error: 2` regarding the `open(c)` call from within the `Open` function. This was caused by the function declaration being capitalized while the subsequent call was not. As you can see in the commit, I simply changed the call from `open(c)` to `Open(c)`. Please accept my request (or update the code at your leisure if I have missed any part of the PR process for go/grid-x).